### PR TITLE
Added "filterWith" and "purge"

### DIFF
--- a/cache.cabal
+++ b/cache.cabal
@@ -1,5 +1,5 @@
 name:           cache
-version:        0.1.2.1
+version:        0.1.3.0
 synopsis:       An in-memory key/value store with expiration support
 homepage:       https://github.com/hverr/haskell-cache#readme
 license:        BSD3

--- a/cache.cabal
+++ b/cache.cabal
@@ -1,5 +1,5 @@
 name:           cache
-version:        0.1.1.2
+version:        0.1.2.1
 synopsis:       An in-memory key/value store with expiration support
 homepage:       https://github.com/hverr/haskell-cache#readme
 license:        BSD3

--- a/src/Data/Cache.hs
+++ b/src/Data/Cache.hs
@@ -40,7 +40,7 @@ module Data.Cache (
     -- ** Deletion
   , delete
   , deleteSTM
-  , filterWith
+  , filterWithKey
   , purge
   , purgeExpired
   , purgeExpiredSTM
@@ -227,11 +227,11 @@ keys = atomically . keysSTM
 now :: IO TimeSpec
 now = getTime Monotonic
 
--- | keeps elements that satify a predicate (used for cache invalidation).
-filterWith :: (Eq k, Hashable k) => (k -> Bool) -> Cache k v -> IO ()
-filterWith f c = atomically $ writeTVar v =<< (HM.filterWithKey (\k _ -> f k) <$> readTVar v) where v = container c
+-- | Keeps elements that satify a predicate (used for cache invalidation).
+filterWithKey :: (Eq k, Hashable k) => (k -> CacheItem v -> Bool) -> Cache k v -> IO ()
+filterWithKey f c = atomically $ writeTVar c' =<< (HM.filterWithKey f <$> readTVar c') where c' = container c
 
--- | delete all elements (cache invalidation).
+-- | Delete all elements (cache invalidation).
 purge :: (Eq k, Hashable k) => Cache k v -> IO ()
 purge c = atomically $ writeTVar v HM.empty where v = container c
 

--- a/src/Data/Cache.hs
+++ b/src/Data/Cache.hs
@@ -40,6 +40,8 @@ module Data.Cache (
     -- ** Deletion
   , delete
   , deleteSTM
+  , filterWith
+  , purge
   , purgeExpired
   , purgeExpiredSTM
     -- ** Combined actions
@@ -224,6 +226,14 @@ keys = atomically . keysSTM
 
 now :: IO TimeSpec
 now = getTime Monotonic
+
+-- | keeps elements that satify a predicate (used for cache invalidation).
+filterWith :: (Eq k, Hashable k) => (k -> Bool) -> Cache k v -> IO ()
+filterWith f c = atomically $ writeTVar v =<< (HM.filterWithKey (\k _ -> f k) <$> readTVar v) where v = container c
+
+-- | delete all elements (cache invalidation).
+purge :: (Eq k, Hashable k) => Cache k v -> IO ()
+purge c = atomically $ writeTVar v HM.empty where v = container c
 
 -- | STM variant of 'purgeExpired'.
 --

--- a/src/Data/Cache.hs
+++ b/src/Data/Cache.hs
@@ -50,6 +50,7 @@ module Data.Cache (
     -- * Cache information
   , size
   , sizeSTM
+  , toList
 ) where
 
 import Prelude hiding (lookup)
@@ -228,8 +229,9 @@ now :: IO TimeSpec
 now = getTime Monotonic
 
 -- | Keeps elements that satify a predicate (used for cache invalidation).
-filterWithKey :: (Eq k, Hashable k) => (k -> CacheItem v -> Bool) -> Cache k v -> IO ()
-filterWithKey f c = atomically $ writeTVar c' =<< (HM.filterWithKey f <$> readTVar c') where c' = container c
+-- | Note that the predicate might be called for expired items.
+filterWithKey :: (Eq k, Hashable k) => (k -> v -> Bool) -> Cache k v -> IO ()
+filterWithKey f c = atomically $ writeTVar c' =<< (HM.filterWithKey (\k (CacheItem v _) -> f k v) <$> readTVar c') where c' = container c
 
 -- | Delete all elements (cache invalidation).
 purge :: (Eq k, Hashable k) => Cache k v -> IO ()
@@ -248,6 +250,14 @@ purgeExpiredSTM c t = mapM_ (\k -> lookupItemT True k c t) =<< keysSTM c
 purgeExpired :: (Eq k, Hashable k) => Cache k v -> IO ()
 purgeExpired c = (atomically . purgeExpiredSTM c) =<< now
 
+-- | returns the cache content as a list.
+-- The third element of the tuple is the expiration date. Nothing means that it doesn't expire.
+toList :: Cache k v -> IO [(k, v, Maybe TimeSpec)]
+toList c = atomically $ do
+  m <- readTVar $ container c
+  let l = HM.toList m
+  return $ map (\(k, (CacheItem v i)) -> (k, v, i)) l
+  
 -- $use
 --
 -- All operations are automically executed in the IO monad. The

--- a/test/Data/CacheSpec.hs
+++ b/test/Data/CacheSpec.hs
@@ -48,6 +48,12 @@ spec = do
         liftIO (lookup' c (fst notExpired)  ) >>= (`shouldBe` Just (snd notExpired))
         liftIO (lookup' c (fst expired)     ) >>= (`shouldBe` Nothing)
         liftIO (lookup' c (fst autoExpired) ) >>= (`shouldBe` Just (snd autoExpired))
+    it "should filter items" $ do
+        c <- liftIO $ defCache Nothing
+        _ <- liftIO $ expire defExpiration
+        liftIO (size c) >>= (`shouldBe` 4)
+        _ <- liftIO $ filterWith (\r -> r /= fst ok) c
+        liftIO (size c) >>= (`shouldBe` 3)
     it "should copy" $ do
         c  <- liftIO $ defCache Nothing
         c' <- liftIO $ copyCache c
@@ -67,6 +73,8 @@ spec = do
         liftIO (size c) >>= (`shouldBe` 4)
         _ <- liftIO $ purgeExpired c
         liftIO (size c) >>= (`shouldBe` 3)
+        _ <- liftIO $ purge c
+        liftIO (size c) >>= (`shouldBe` 0)
     it "should work with actions" $ do
         c <- liftIO $ defCache Nothing
         _ <- liftIO $ expire defExpiration

--- a/test/Data/CacheSpec.hs
+++ b/test/Data/CacheSpec.hs
@@ -52,7 +52,7 @@ spec = do
         c <- liftIO $ defCache Nothing
         _ <- liftIO $ expire defExpiration
         liftIO (size c) >>= (`shouldBe` 4)
-        _ <- liftIO $ filterWith (\r -> r /= fst ok) c
+        _ <- liftIO $ filterWithKey (\r _ -> r /= fst ok) c
         liftIO (size c) >>= (`shouldBe` 3)
     it "should copy" $ do
         c  <- liftIO $ defCache Nothing

--- a/test/Data/CacheSpec.hs
+++ b/test/Data/CacheSpec.hs
@@ -67,6 +67,13 @@ spec = do
         liftIO (size c) >>= (`shouldBe` 4)
         _ <- liftIO $ purgeExpired c
         liftIO (size c) >>= (`shouldBe` 3)
+    it "should work with actions" $ do
+        c <- liftIO $ defCache Nothing
+        _ <- liftIO $ expire defExpiration
+        liftIO (fetchWithCache c (fst ok) (const $ return 10))               >>= (`shouldBe` (snd ok))
+        liftIO (fetchWithCache c (fst expired) (const $ return 10))          >>= (`shouldBe` 10)
+        liftIO (fetchWithCache c (fst action) (const $ return (snd action))) >>= (`shouldBe` (snd action))
+        liftIO (lookup' c (fst action) )                                     >>= (`shouldBe` Just (snd action))
 
 defExpiration :: TimeSpec
 defExpiration = 1000000
@@ -91,6 +98,9 @@ notAvailable = ("not available", 2)
 
 ok :: (String, Int)
 ok = ("ok", 3)
+
+action :: (String, Int)
+action = ("action", 6)
 
 defCache :: Maybe TimeSpec -> IO (Cache String Int)
 defCache t = do


### PR DESCRIPTION
I wanted to propose to add two more functions:
- `filterWith :: (Eq k, Hashable k) => (k -> Bool) -> Cache k v -> IO ()`
- `purge :: (Eq k, Hashable k) => Cache k v -> IO ()`

They can be useful to invalidate the cache: something can happens in the system that should invalidate some cache entries, or all of them.
I also generalized `fetchWithCache`:
- `fetchWithCache :: (Eq k, Hashable k, MonadIO m) => Cache k v -> k -> (k -> m v) -> m v`

This is useful when the argument function is working in a different stack than IO.